### PR TITLE
Fix error caused by empty response to updates to `renewal-info` resource (ARI)

### DIFF
--- a/src/ACMESharp/Protocol/AcmeProtocolClient.cs
+++ b/src/ACMESharp/Protocol/AcmeProtocolClient.cs
@@ -459,22 +459,22 @@ namespace ACMESharp.Protocol
         /// </summary>
         /// <param name="certificateId"></param>
         /// <returns></returns>
-        public async Task<object> UpdateRenewalInfo(byte[] certificateId)
+        public async Task UpdateRenewalInfo(byte[] certificateId)
         {
             if (string.IsNullOrWhiteSpace(Directory.RenewalInfo))
             {
-                return new object();
+                return;
             }
             var request = new UpdateRenewalInfoRequest()
             {
                 CertificateId = Base64Tool.UrlEncode(certificateId),
                 Replaced = true
             };
-            return await SendAcmeAsync(
+            var serialized = JsonSerializer.Serialize(request, AcmeJson.Insensitive.UpdateRenewalInfoRequest);
+            serialized = ComputeAcmeSigned(serialized, Directory.RenewalInfo);
+            _ = await SendAcmeAsync(
                 Directory.RenewalInfo,
-                AcmeJson.Insensitive.UpdateRenewalInfoRequest,
-                AcmeJson.Insensitive.Object,
-                message: request);
+                message: serialized);
         }
 
         /// <summary>


### PR DESCRIPTION
win-acme's fork of ACMESharpCore expects a non-empty response for updates to the `renewal-info` resource.
However, Let's Encrypt responds with an empty body, which actually seems to conform to [section 4.2 of draft-ietf-acme-ari-00](https://www.ietf.org/archive/id/draft-ietf-acme-ari-00.html#name-updating-renewal-informatio).
As a result, the following error is reported during renewal:
```
Error updating renewal info: The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. Path: $ | LineNumber: 0 | BytePositionInLine: 0.
```

This pull request modifies `AcmeProtocolClient.UpdateRenewalInfo()` to not expect the HTTP response to have a non-empty body.

Please expect a follow-up pull request to the win-acme repository due to the updated submodule reference and the change in the signature of `UpdateRenewalInfo()`.

Related to win-acme/win-acme#2353.